### PR TITLE
Fix bug where relation was not lowercased

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,12 @@ package ent
 
 #### Usage
 
+When creating the `*ent.Client` add the following to enable the authz hooks:
+
+```
+	client.WithAuthz()
+```
+
 In the `ent` schema, provide the following annotation:
 
 ```go 

--- a/entfga/templates/authzFromMutation.tmpl
+++ b/entfga/templates/authzFromMutation.tmpl
@@ -22,10 +22,7 @@
             role, _ := m.Role()
 
             // get tuple key 
-            tuple, err := fgax.GetTupleKey(userID, "user", objectID, "{{ $objectType | ToLower }}" , role.String())
-            if err != nil {
-                return err
-            }
+            tuple := fgax.GetTupleKey(userID, "user", objectID, "{{ $objectType | ToLower }}" , role.String())
 
             if _, err := m.Authz.WriteTupleKeys(ctx, []fgax.TupleKey{tuple}, nil); err != nil {
                 m.Logger.Errorw("failed to create relationship tuple", "error", err)
@@ -80,17 +77,11 @@
                     return err
                 }
 
-                d, err := fgax.GetTupleKey(member.UserID, "user", member.{{ $objectType | ToUpperCamel }}ID, "{{ $objectType | ToLower }}", oldRole.String())
-                if err != nil {
-                    return err
-                }
+                d := fgax.GetTupleKey(member.UserID, "user", member.{{ $objectType | ToUpperCamel }}ID, "{{ $objectType | ToLower }}", oldRole.String())
 
                 deletes = append(deletes, d)
 
-                w, err := fgax.GetTupleKey(member.UserID, "user", member.{{ $objectType | ToUpperCamel }}ID, "{{ $objectType | ToLower }}", newRole.String())
-                if err != nil {
-                    return err
-                }
+                w := fgax.GetTupleKey(member.UserID, "user", member.{{ $objectType | ToUpperCamel }}ID, "{{ $objectType | ToLower }}", newRole.String())
 
                 writes = append(writes, w)
 
@@ -134,10 +125,7 @@
                     return err
                 }
 
-                t, err := fgax.GetTupleKey(members.UserID, "user", members.{{ $objectType | ToUpperCamel }}ID, "{{ $objectType | ToLower }}", members.Role.String())
-                if err != nil {
-                    return err
-                }
+                t := fgax.GetTupleKey(members.UserID, "user", members.{{ $objectType | ToUpperCamel }}ID, "{{ $objectType | ToLower }}", members.Role.String())
 
                 tuples = append(tuples, t)
             }

--- a/tuples.go
+++ b/tuples.go
@@ -97,7 +97,7 @@ func tupleKeyToWriteRequest(writes []TupleKey) (w []ofgaclient.ClientTupleKey) {
 		ctk := ofgaclient.ClientTupleKey{}
 		ctk.SetObject(k.Object.String())
 		ctk.SetUser(k.Subject.String())
-		ctk.SetRelation(string(k.Relation))
+		ctk.SetRelation(k.Relation.String())
 
 		w = append(w, ctk)
 	}
@@ -223,7 +223,7 @@ func (c *Client) DeleteAllObjectRelations(ctx context.Context, object string) er
 }
 
 // GetTupleKey creates a Tuple key with the provided subject, object, and role
-func GetTupleKey(subjectID, subjectType, objectID, objectType string, relation string) (TupleKey, error) {
+func GetTupleKey(subjectID, subjectType, objectID, objectType, relation string) TupleKey {
 	sub := Entity{
 		Kind:       Kind(subjectType),
 		Identifier: subjectID,
@@ -238,5 +238,5 @@ func GetTupleKey(subjectID, subjectType, objectID, objectType string, relation s
 		Subject:  sub,
 		Object:   object,
 		Relation: Relation(relation),
-	}, nil
+	}
 }

--- a/tuples_test.go
+++ b/tuples_test.go
@@ -4,10 +4,9 @@ import (
 	"context"
 	"testing"
 
+	mock_fga "github.com/datumforge/fgax/mockery"
 	openfga "github.com/openfga/go-sdk"
 	"github.com/stretchr/testify/assert"
-
-	mock_fga "github.com/datumforge/fgax/mockery"
 )
 
 func Test_EntityString(t *testing.T) {
@@ -133,6 +132,26 @@ func Test_tupleKeyToWriteRequest(t *testing.T) {
 					Relation: "member",
 					Object: Entity{
 						Kind:       "organization",
+						Identifier: "IDOFTHEORG",
+					},
+				},
+			},
+			expectedUser:     "user:THEBESTUSER",
+			expectedRelation: "member",
+			expectedObject:   "organization:IDOFTHEORG",
+			expectedCount:    1,
+		},
+		{
+			name: "happy path, should lowercase kind and relations",
+			writes: []TupleKey{
+				{
+					Subject: Entity{
+						Kind:       "USER",
+						Identifier: "THEBESTUSER",
+					},
+					Relation: "MEMBER",
+					Object: Entity{
+						Kind:       "ORGANIZATION",
 						Identifier: "IDOFTHEORG",
 					},
 				},
@@ -402,6 +421,51 @@ func Test_DeleteRelationshipTuple(t *testing.T) {
 			}
 
 			assert.NoError(t, err)
+		})
+	}
+}
+
+func TestGetTupleKey(t *testing.T) {
+	type args struct {
+		subjectID   string
+		subjectType string
+		objectID    string
+		objectType  string
+		relation    string
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    TupleKey
+		wantErr bool
+	}{
+		{
+			name: "happy path",
+			args: args{
+				subjectID:   "HIITSME",
+				subjectType: "user",
+				objectType:  "organization",
+				objectID:    "MIDNIGHTSAFTERNOON",
+				relation:    "member",
+			},
+			want: TupleKey{
+				Subject: Entity{
+					Kind:       "user",
+					Identifier: "HIITSME",
+				},
+				Relation: "member",
+				Object: Entity{
+					Kind:       "organization",
+					Identifier: "MIDNIGHTSAFTERNOON",
+				},
+			},
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := GetTupleKey(tt.args.subjectID, tt.args.subjectType, tt.args.objectID, tt.args.objectType, tt.args.relation)
+			assert.Equal(t, tt.want, got)
 		})
 	}
 }


### PR DESCRIPTION
- Fixes relation to use the correct `.String()` function to lowercase the value
- Add test case 
- Update README with adding the hooks to the ent client