### PR TITLE
fix relations in delete requests

### DIFF
--- a/tuples.go
+++ b/tuples.go
@@ -111,7 +111,7 @@ func tupleKeyToDeleteRequest(deletes []TupleKey) (d []openfga.TupleKeyWithoutCon
 		ctk := openfga.TupleKeyWithoutCondition{}
 		ctk.SetObject(k.Object.String())
 		ctk.SetUser(k.Subject.String())
-		ctk.SetRelation(string(k.Relation))
+		ctk.SetRelation(k.Relation.String())
 
 		d = append(d, ctk)
 	}

--- a/tuples_test.go
+++ b/tuples_test.go
@@ -257,6 +257,26 @@ func Test_tupleKeyToDeleteRequest(t *testing.T) {
 			expectedCount:    1,
 		},
 		{
+			name: "happy path, uppercase",
+			writes: []TupleKey{
+				{
+					Subject: Entity{
+						Kind:       "USER",
+						Identifier: "THEBESTUSER",
+					},
+					Relation: "MEMBER",
+					Object: Entity{
+						Kind:       "ORGANIZATION",
+						Identifier: "IDOFTHEORG",
+					},
+				},
+			},
+			expectedUser:     "user:THEBESTUSER",
+			expectedRelation: "member",
+			expectedObject:   "organization:IDOFTHEORG",
+			expectedCount:    1,
+		},
+		{
 			name: "happy path, group",
 			writes: []TupleKey{
 				{


### PR DESCRIPTION
fixes a bug where relations could not be deleted because the value was in uppercase `relation: 'OWNER',`

after fix:

```
{
  "deleteOrganization": {
    "deletedID": "01HNKR9SD8R85P874HX9PSX71X"
  }
}
```