### PR TITLE
bug fix: fix missing object type on queries, fix join table checks

### DIFF
--- a/entfga/_examples/basic/ent/authz_checks.go
+++ b/entfga/_examples/basic/ent/authz_checks.go
@@ -11,6 +11,8 @@ import (
 	"github.com/99designs/gqlgen/graphql"
 	"github.com/datumforge/fgax"
 	"github.com/datumforge/fgax/entfga/_examples/basic/auth"
+	"github.com/datumforge/fgax/entfga/_examples/basic/ent/organization"
+	"github.com/datumforge/fgax/entfga/_examples/basic/ent/orgmembership"
 )
 
 func (q *OrgMembershipQuery) CheckAccess(ctx context.Context) error {
@@ -18,11 +20,13 @@ func (q *OrgMembershipQuery) CheckAccess(ctx context.Context) error {
 
 	if gCtx != nil {
 		ac := fgax.AccessCheck{
-			Relation: fgax.CanView,
+			Relation:   fgax.CanView,
+			ObjectType: "organization",
 		}
 
 		// check id from graphql arg context
 		// when all objects are requested, the interceptor will check object access
+		// check the where input first
 		whereArg := gCtx.Args["where"]
 		if whereArg != nil {
 			where, ok := whereArg.(*OrgMembershipWhereInput)
@@ -31,12 +35,29 @@ func (q *OrgMembershipQuery) CheckAccess(ctx context.Context) error {
 			}
 		}
 
+		// if that doesn't work, check for the id in the args
 		if ac.ObjectID == "" {
-			var ok bool
-			ac.ObjectID, ok = gCtx.Args["id"].(string)
-			if !ok {
+			ac.ObjectID, _ = gCtx.Args["organizationid"].(string)
+		}
+
+		// if we still don't have an object id, run the query and grab the object ID
+		// from the result
+		// this happens on join tables where we have the join ID (for updates and deletes)
+		// and not the actual object id
+		if ac.ObjectID == "" && "id" != "organizationid" {
+			// allow this query to run
+			reqCtx := privacy.DecisionContext(ctx, privacy.Allow)
+			ob, err := q.Only(reqCtx)
+			if err != nil {
 				return privacy.Allowf("nil request, bypassing auth check")
 			}
+
+			ac.ObjectID = ob.OrganizationID
+		}
+
+		// request is for a list objects, will get filtered in interceptors
+		if ac.ObjectID == "" {
+			return privacy.Allowf("nil request, bypassing auth check")
 		}
 
 		var err error
@@ -76,12 +97,30 @@ func (m *OrgMembershipMutation) CheckAccessForEdit(ctx context.Context) error {
 		ac.ObjectID = input.OrganizationID
 	}
 
+	// check the id from the args
 	if ac.ObjectID == "" {
-		var ok bool
-		ac.ObjectID, ok = gCtx.Args["id"].(string)
-		if !ok {
-			return privacy.Allowf("nil request, bypassing auth check")
+		ac.ObjectID, _ = gCtx.Args["organizationid"].(string)
+	}
+
+	// if this is still empty, we need to query the object to get the object id
+	// this happens on join tables where we have the join ID (for updates and deletes)
+	if ac.ObjectID == "" && "id" != "organizationid" {
+		id, ok := gCtx.Args["id"].(string)
+		if ok {
+			// allow this query to run
+			reqCtx := privacy.DecisionContext(ctx, privacy.Allow)
+			ob, err := m.Client().OrgMembership.Query().Where(orgmembership.ID(id)).Only(reqCtx)
+			if err != nil {
+				return privacy.Allowf("nil request, bypassing auth check")
+			}
+
+			ac.ObjectID = ob.OrganizationID
 		}
+	}
+
+	// request is for a list objects, will get filtered in interceptors
+	if ac.ObjectID == "" {
+		return privacy.Allowf("nil request, bypassing auth check")
 	}
 
 	m.Logger.Debugw("checking mutation access")
@@ -153,11 +192,13 @@ func (q *OrganizationQuery) CheckAccess(ctx context.Context) error {
 
 	if gCtx != nil {
 		ac := fgax.AccessCheck{
-			Relation: fgax.CanView,
+			Relation:   fgax.CanView,
+			ObjectType: "organization",
 		}
 
 		// check id from graphql arg context
 		// when all objects are requested, the interceptor will check object access
+		// check the where input first
 		whereArg := gCtx.Args["where"]
 		if whereArg != nil {
 			where, ok := whereArg.(*OrganizationWhereInput)
@@ -166,12 +207,29 @@ func (q *OrganizationQuery) CheckAccess(ctx context.Context) error {
 			}
 		}
 
+		// if that doesn't work, check for the id in the args
 		if ac.ObjectID == "" {
-			var ok bool
-			ac.ObjectID, ok = gCtx.Args["id"].(string)
-			if !ok {
+			ac.ObjectID, _ = gCtx.Args["id"].(string)
+		}
+
+		// if we still don't have an object id, run the query and grab the object ID
+		// from the result
+		// this happens on join tables where we have the join ID (for updates and deletes)
+		// and not the actual object id
+		if ac.ObjectID == "" && "id" != "id" {
+			// allow this query to run
+			reqCtx := privacy.DecisionContext(ctx, privacy.Allow)
+			ob, err := q.Only(reqCtx)
+			if err != nil {
 				return privacy.Allowf("nil request, bypassing auth check")
 			}
+
+			ac.ObjectID = ob.ID
+		}
+
+		// request is for a list objects, will get filtered in interceptors
+		if ac.ObjectID == "" {
+			return privacy.Allowf("nil request, bypassing auth check")
 		}
 
 		var err error
@@ -202,12 +260,30 @@ func (m *OrganizationMutation) CheckAccessForEdit(ctx context.Context) error {
 
 	gCtx := graphql.GetFieldContext(ctx)
 
+	// check the id from the args
 	if ac.ObjectID == "" {
-		var ok bool
-		ac.ObjectID, ok = gCtx.Args["id"].(string)
-		if !ok {
-			return privacy.Allowf("nil request, bypassing auth check")
+		ac.ObjectID, _ = gCtx.Args["id"].(string)
+	}
+
+	// if this is still empty, we need to query the object to get the object id
+	// this happens on join tables where we have the join ID (for updates and deletes)
+	if ac.ObjectID == "" && "id" != "id" {
+		id, ok := gCtx.Args["id"].(string)
+		if ok {
+			// allow this query to run
+			reqCtx := privacy.DecisionContext(ctx, privacy.Allow)
+			ob, err := m.Client().Organization.Query().Where(organization.ID(id)).Only(reqCtx)
+			if err != nil {
+				return privacy.Allowf("nil request, bypassing auth check")
+			}
+
+			ac.ObjectID = ob.ID
 		}
+	}
+
+	// request is for a list objects, will get filtered in interceptors
+	if ac.ObjectID == "" {
+		return privacy.Allowf("nil request, bypassing auth check")
 	}
 
 	m.Logger.Debugw("checking mutation access")

--- a/entfga/templates/authzChecks.tmpl
+++ b/entfga/templates/authzChecks.tmpl
@@ -32,24 +32,43 @@ import (
             if gCtx != nil {
                 ac := fgax.AccessCheck{
                     Relation: fgax.CanView,
+                    ObjectType:  "{{ $objectType | ToLower }}",
                 }
 
                 // check id from graphql arg context
                 // when all objects are requested, the interceptor will check object access
+                // check the where input first
                 whereArg := gCtx.Args["where"]
                 if whereArg != nil {
-                    where, ok  := whereArg.(*{{ $name }}WhereInput)
+                    where, ok := whereArg.(*{{ $name }}WhereInput)
                     if ok && where != nil && where.{{ $idField }} != nil {
                         ac.ObjectID = *where.{{ $idField }}
-                    } 
+                    }
                 }
 
+                // if that doesn't work, check for the id in the args
                 if ac.ObjectID == "" {
-                    var ok bool
-                    ac.ObjectID, ok = gCtx.Args["id"].(string)
-                    if !ok {
+                    ac.ObjectID, _ = gCtx.Args["{{ $idField | ToLower }}"].(string)
+                }
+            
+                // if we still don't have an object id, run the query and grab the object ID 
+                // from the result
+                // this happens on join tables where we have the join ID (for updates and deletes)
+                // and not the actual object id
+                if ac.ObjectID == "" && "id" !=  "{{ $idField | ToLower }}" {
+                    // allow this query to run
+                    reqCtx := privacy.DecisionContext(ctx, privacy.Allow)
+                    ob, err := q.Only(reqCtx)
+                    if err != nil {
                         return privacy.Allowf("nil request, bypassing auth check")
                     }
+                    
+                    ac.ObjectID = ob.{{ $idField }}
+                }
+
+                // request is for a list objects, will get filtered in interceptors
+                if ac.ObjectID == ""  {
+                    return privacy.Allowf("nil request, bypassing auth check")
                 }
 
                 var err error
@@ -91,13 +110,31 @@ import (
                 ac.ObjectID = input.{{ $idField }}
             } 
             {{ end }}
-            
+
+            // check the id from the args
             if ac.ObjectID == "" {
-                var ok bool
-                ac.ObjectID, ok = gCtx.Args["id"].(string)
-                if !ok {
-                    return privacy.Allowf("nil request, bypassing auth check")
+                ac.ObjectID, _ = gCtx.Args["{{ $idField | ToLower }}"].(string)
+            }
+
+            // if this is still empty, we need to query the object to get the object id
+            // this happens on join tables where we have the join ID (for updates and deletes)
+            if ac.ObjectID == "" && "id" !=  "{{ $idField | ToLower }}" {
+                id, ok := gCtx.Args["id"].(string)
+                if ok {
+                    // allow this query to run
+                    reqCtx := privacy.DecisionContext(ctx, privacy.Allow)
+                    ob, err := m.Client().{{ $name }}.Query().Where({{ $name | ToLower }}.ID(id)).Only(reqCtx)
+                    if err != nil {
+                        return privacy.Allowf("nil request, bypassing auth check")
+                    }
+
+                    ac.ObjectID = ob.{{ $idField }}
                 }
+            }
+
+            // request is for a list objects, will get filtered in interceptors
+            if ac.ObjectID == ""  {
+                return privacy.Allowf("nil request, bypassing auth check")
             }
 
             m.Logger.Debugw("checking mutation access")


### PR DESCRIPTION
Address two issues:
1. Missing object type on query access checks
2. Incorrect object id when doing updates and deletes on join tables where the id is not the actual object id