### PR TITLE
fix psql issue, clone query for checks

### DIFF
--- a/entfga/_examples/basic/ent/authz_checks.go
+++ b/entfga/_examples/basic/ent/authz_checks.go
@@ -47,7 +47,7 @@ func (q *OrgMembershipQuery) CheckAccess(ctx context.Context) error {
 		if ac.ObjectID == "" && "id" != "organizationid" {
 			// allow this query to run
 			reqCtx := privacy.DecisionContext(ctx, privacy.Allow)
-			ob, err := q.Only(reqCtx)
+			ob, err := q.Clone().Only(reqCtx)
 			if err != nil {
 				return privacy.Allowf("nil request, bypassing auth check")
 			}
@@ -219,7 +219,7 @@ func (q *OrganizationQuery) CheckAccess(ctx context.Context) error {
 		if ac.ObjectID == "" && "id" != "id" {
 			// allow this query to run
 			reqCtx := privacy.DecisionContext(ctx, privacy.Allow)
-			ob, err := q.Only(reqCtx)
+			ob, err := q.Clone().Only(reqCtx)
 			if err != nil {
 				return privacy.Allowf("nil request, bypassing auth check")
 			}

--- a/entfga/templates/authzChecks.tmpl
+++ b/entfga/templates/authzChecks.tmpl
@@ -58,7 +58,7 @@ import (
                 if ac.ObjectID == "" && "id" !=  "{{ $idField | ToLower }}" {
                     // allow this query to run
                     reqCtx := privacy.DecisionContext(ctx, privacy.Allow)
-                    ob, err := q.Only(reqCtx)
+                    ob, err := q.Clone().Only(reqCtx)
                     if err != nil {
                         return privacy.Allowf("nil request, bypassing auth check")
                     }


### PR DESCRIPTION
Fixes issue when using `psql` where these checks would result in the following error:

```
could not determine data type of parameter $1
```

Ent issue ref for solution: https://github.com/ent/ent/issues/2955