### PR TITLE
add check for system admin

### DIFF
--- a/checks.go
+++ b/checks.go
@@ -81,6 +81,18 @@ func (c *Client) CheckGroupAccess(ctx context.Context, userID, groupID, relation
 	return c.CheckAccess(ctx, ac)
 }
 
+// CheckSystemAdminRole checks if the user has system admin access
+func (c *Client) CheckSystemAdminRole(ctx context.Context, userID string) (bool, error) {
+	ac := AccessCheck{
+		ObjectType: "role",
+		ObjectID:   SystemAdminRole,
+		Relation:   RoleRelation,
+		UserID:     userID,
+	}
+
+	return c.CheckAccess(ctx, ac)
+}
+
 // validateAccessCheck checks if the AccessCheck struct is valid
 func validateAccessCheck(ac AccessCheck) error {
 	if ac.UserID == "" {

--- a/tuples.go
+++ b/tuples.go
@@ -9,15 +9,26 @@ import (
 	ofgaclient "github.com/openfga/go-sdk/client"
 )
 
+// setup relations for use in creating tuples
 const (
-	// setup relations for use in creating tuples
+	// SystemAdminRole is the role for system admins that have the highest level of access
+	SystemAdminRole = "system_admin"
+	// MemberRelation is the relation for members of an entity
 	MemberRelation = "member"
-	AdminRelation  = "admin"
-	OwnerRelation  = "owner"
+	// AdminRelation is the relation for admins of an entity
+	AdminRelation = "admin"
+	// OwnerRelation is the relation for owners of an entity
+	OwnerRelation = "owner"
+	// ParentRelation is the relation for parents of an entity
 	ParentRelation = "parent"
-	CanView        = "can_view"
-	CanEdit        = "can_edit"
-	CanDelete      = "can_delete"
+	// AssigneeRoleRelation is the relation for assignees of an entity
+	RoleRelation = "assignee"
+	// CanView is the relation for viewing an entity
+	CanView = "can_view"
+	// CanEdit is the relation for editing an entity
+	CanEdit = "can_edit"
+	// CanDelete is the relation for deleting an entity
+	CanDelete = "can_delete"
 )
 
 type TupleKey struct {


### PR DESCRIPTION
Adds the ability to check for a `role` in fga for overall system admin 

```
2024-03-17T11:32:09.037-0600	INFO	fgax@v0.1.4-0.20240317172940-9fd389f90f01/checks.go:49	checking relationship tuples	{"relation": "assignee", "object": "role:system_admin"}
```
