### PR TITLE
feat: only create mutation access checks if EntGQL annotation set on schema

### DIFF
--- a/entfga/template.go
+++ b/entfga/template.go
@@ -66,6 +66,23 @@ func hasCreateID(val any) bool {
 	return true
 }
 
+// hasMutationInputSet checks if the annotation for MutationInputs is set on the schema
+// this annotation would look like:
+// `entgql.Mutations(entgql.MutationCreate(), entgql.MutationUpdate()),`
+// on an ent schema
+func hasMutationInputSet(val any) bool {
+	annotation, ok := val.(map[string]interface{})
+	if !ok {
+		return false
+	}
+
+	if res, ok := annotation["MutationInputs"]; ok && res != nil {
+		return true
+	}
+
+	return false
+}
+
 // extractIncludeHooks gets the key that is used to determine if the hooks should be included
 func extractIncludeHooks(val any) bool {
 	includeHooks, ok := val.(bool)
@@ -90,6 +107,7 @@ func parseTemplate(name, path string) *gen.Template {
 		"extractNillableIDField": extractNillableIDField,
 		"extractOrgOwnedField":   extractOrgOwnedField,
 		"hasCreateID":            hasCreateID,
+		"hasMutationInputSet":    hasMutationInputSet,
 		"extractIncludeHooks":    extractIncludeHooks,
 		"useSoftDeletes":         useSoftDeletes,
 		"ToUpperCamel":           strcase.UpperCamelCase,

--- a/entfga/template_test.go
+++ b/entfga/template_test.go
@@ -1,0 +1,43 @@
+package entfga
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_hasMutationInputSet(t *testing.T) {
+	testCases := []struct {
+		name     string
+		input    any
+		expected bool
+	}{
+		{
+			name:     "mutation inputs set",
+			input:    map[string]interface{}{"MutationInputs": map[string]interface{}{"IsCreate": true}},
+			expected: true,
+		},
+		{
+			name:     "mutation inputs not set",
+			input:    map[string]interface{}{},
+			expected: false,
+		},
+		{
+			name:     "mutation inputs set to nil",
+			input:    map[string]interface{}{"MutationInputs": nil},
+			expected: false,
+		},
+		{
+			name:     "invalid input type",
+			input:    "invalid",
+			expected: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			result := hasMutationInputSet(tc.input)
+			assert.Equal(t, tc.expected, result)
+		})
+	}
+}

--- a/entfga/templates/authzChecks.tmpl
+++ b/entfga/templates/authzChecks.tmpl
@@ -95,6 +95,7 @@ import (
             return privacy.Skip
         }
 
+        {{if $n.Annotations.EntGQL | hasMutationInputSet }}
         func (m *{{ $mutator }}) CheckAccessForEdit(ctx context.Context) error {
             ac := fgax.AccessCheck{
                 Relation: fgax.CanEdit,
@@ -218,6 +219,7 @@ import (
             // deny if it was a mutation is not allowed
             return privacy.Deny
         }
+        {{ end }}
     {{ end }}
     {{ end }}
 {{ end }}


### PR DESCRIPTION
This will only create the Mutation access checks if the `EntGQL` annotation is set for mutations; this is what generates the `Input` structs required for these checks. If the annotation isn't used, there are no resolvers for Create/Update/Delete.

This is checking for this `Annotation` on the schema:

```
entgql.Mutations(entgql.MutationCreate(), entgql.MutationUpdate()),
```

This is a no-op in our current schema, but when adding the FGA checks for the history tables, this is needed to exclude the Mutation checks because no mutations are allowed/resolvers are not created.