### PR TITLE
feat: add list relations function

### DIFF
--- a/checks.go
+++ b/checks.go
@@ -157,14 +157,14 @@ func (c *Client) checkTuple(ctx context.Context, check ofgaclient.ClientCheckReq
 // batchCheckTuples checks the openFGA store for provided relationship tuples and returns the allowed relations
 func (c *Client) batchCheckTuples(ctx context.Context, checks []ofgaclient.ClientCheckRequest) ([]string, error) {
 	res, err := c.Ofga.BatchCheck(ctx).Body(checks).Execute()
-	if err != nil {
+	if err != nil || res == nil {
 		return nil, err
 	}
 
 	relations := []string{}
 
 	for _, r := range *res {
-		if *r.Allowed {
+		if r.Allowed != nil && *r.Allowed {
 			relations = append(relations, r.Request.Relation)
 		}
 	}

--- a/checks.go
+++ b/checks.go
@@ -162,6 +162,7 @@ func (c *Client) batchCheckTuples(ctx context.Context, checks []ofgaclient.Clien
 	}
 
 	relations := []string{}
+
 	for _, r := range *res {
 		if *r.Allowed {
 			relations = append(relations, r.Request.Relation)

--- a/checks.go
+++ b/checks.go
@@ -42,7 +42,7 @@ type ListAccess struct {
 	SubjectID string
 	// SubjectType is the type of subject being checked
 	SubjectType string
-	// Relations is the relationship being checked (e.g. "view", "edit", "delete")
+	// Relations is the relationship being checked (e.g. "can_view", "can_edit", "can_delete")
 	Relations []string
 }
 
@@ -154,7 +154,7 @@ func (c *Client) checkTuple(ctx context.Context, check ofgaclient.ClientCheckReq
 	return *data.Allowed, nil
 }
 
-// checkTuple checks the openFGA store for provided relationship tuple
+// batchCheckTuples checks the openFGA store for provided relationship tuples and returns the allowed relations
 func (c *Client) batchCheckTuples(ctx context.Context, checks []ofgaclient.ClientCheckRequest) ([]string, error) {
 	res, err := c.Ofga.BatchCheck(ctx).Body(checks).Execute()
 	if err != nil {
@@ -167,6 +167,7 @@ func (c *Client) batchCheckTuples(ctx context.Context, checks []ofgaclient.Clien
 			relations = append(relations, r.Request.Relation)
 		}
 	}
+
 	return relations, nil
 }
 

--- a/checks.go
+++ b/checks.go
@@ -32,6 +32,20 @@ type AccessCheck struct {
 	Relation string
 }
 
+// ListAccess is a struct to hold the information needed to list all relations
+type ListAccess struct {
+	// ObjectType is the type of object being checked
+	ObjectType Kind
+	// ObjectID is the ID of the object being checked
+	ObjectID string
+	// SubjectID is the ID of the user making the request
+	SubjectID string
+	// SubjectType is the type of subject being checked
+	SubjectType string
+	// Relations is the relationship being checked (e.g. "view", "edit", "delete")
+	Relations []string
+}
+
 // CheckAccess checks if the user has access to the object type with the given relation
 func (c *Client) CheckAccess(ctx context.Context, ac AccessCheck) (bool, error) {
 	if err := validateAccessCheck(ac); err != nil {
@@ -61,6 +75,41 @@ func (c *Client) CheckAccess(ctx context.Context, ac AccessCheck) (bool, error) 
 	}
 
 	return c.checkTuple(ctx, checkReq)
+}
+
+// ListRelations returns the list of relations the user has with the object
+func (c *Client) ListRelations(ctx context.Context, ac ListAccess) ([]string, error) {
+	if err := validateListAccess(ac); err != nil {
+		return nil, err
+	}
+
+	if ac.SubjectType == "" {
+		ac.SubjectType = defaultSubject
+	}
+
+	sub := Entity{
+		Kind:       Kind(ac.SubjectType),
+		Identifier: ac.SubjectID,
+	}
+
+	obj := Entity{
+		Kind:       ac.ObjectType,
+		Identifier: ac.ObjectID,
+	}
+
+	checks := []ofgaclient.ClientCheckRequest{}
+
+	for _, rel := range ac.Relations {
+		check := ofgaclient.ClientCheckRequest{
+			User:     sub.String(),
+			Relation: rel,
+			Object:   obj.String(),
+		}
+
+		checks = append(checks, check)
+	}
+
+	return c.batchCheckTuples(ctx, checks)
 }
 
 // CheckOrgReadAccess checks if the user has read access to the organization
@@ -105,6 +154,22 @@ func (c *Client) checkTuple(ctx context.Context, check ofgaclient.ClientCheckReq
 	return *data.Allowed, nil
 }
 
+// checkTuple checks the openFGA store for provided relationship tuple
+func (c *Client) batchCheckTuples(ctx context.Context, checks []ofgaclient.ClientCheckRequest) ([]string, error) {
+	res, err := c.Ofga.BatchCheck(ctx).Body(checks).Execute()
+	if err != nil {
+		return nil, err
+	}
+
+	relations := []string{}
+	for _, r := range *res {
+		if *r.Allowed {
+			relations = append(relations, r.Request.Relation)
+		}
+	}
+	return relations, nil
+}
+
 // CheckSystemAdminRole checks if the user has system admin access
 func (c *Client) CheckSystemAdminRole(ctx context.Context, userID string) (bool, error) {
 	ac := AccessCheck{
@@ -133,6 +198,23 @@ func validateAccessCheck(ac AccessCheck) error {
 	}
 
 	if ac.Relation == "" {
+		return ErrInvalidAccessCheck
+	}
+
+	return nil
+}
+
+// validateListAccess checks if the ListAccess struct is valid
+func validateListAccess(ac ListAccess) error {
+	if ac.SubjectID == "" {
+		return ErrInvalidAccessCheck
+	}
+
+	if ac.ObjectType == "" {
+		return ErrInvalidAccessCheck
+	}
+
+	if ac.ObjectID == "" {
 		return ErrInvalidAccessCheck
 	}
 


### PR DESCRIPTION
There is currently now `ListRelations` built into the FGA api (like `ListObjects` or `ListUsers`) but this takes advantage of the `BatchCheck` which will take a list of relations and return the allow status of each and will only return the allowed relations of the user in a `[]string{}`